### PR TITLE
Add end-to-end travellerReference support across offers, selection and travel parties

### DIFF
--- a/OMSA.yaml
+++ b/OMSA.yaml
@@ -1601,12 +1601,23 @@ components:
       - type: object
         required:
         - type
-        - offerIds
+        - selections
         properties:
-          offerIds:
+          selections:
             type: array
+            description: "Component-based selection of offers and their ancillaries."
             items:
-              $ref: "#/components/schemas/offerReference"
+              type: object
+              required:
+                - offerId
+              properties:
+                offerId:
+                  $ref: "#/components/schemas/offerReference"
+                selectedAncillaryIds:
+                  type: array
+                  description: "List of ancillaryIds to include specifically for this offer instance."
+                  items:
+                    $ref: "#/components/schemas/ancillaryReference"
           type:
             type: string
             enum: [ select_offers ]
@@ -3084,6 +3095,15 @@ components:
           type:
             type: string
             enum: [ ancillary ]
+          price:
+            $ref: "#/components/schemas/amountOfMoney"
+            description: "The additional cost of this ancillary if selected."
+          description:
+            type: string
+            description: "A user-friendly description of the ancillary (e.g. 'Reserved seat for bike')."
+          available:
+            type: integer
+            description: "Number of items available in stock (inventory). Useful for creating urgency in GUI."
           links:
             type: array
             items:

--- a/OMSA.yaml
+++ b/OMSA.yaml
@@ -1603,6 +1603,9 @@ components:
         - type
         - selections
         properties:
+          type:
+            type: string
+            enum: [ select_offers ]
           selections:
             type: array
             description: "Component-based selection of offers and their ancillaries."
@@ -1610,17 +1613,25 @@ components:
               type: object
               required:
                 - offerId
+                - travellerIds
               properties:
                 offerId:
                   $ref: "#/components/schemas/offerReference"
+                travellerIds:
+                  type: array
+                  minItems: 1
+                  description: >
+                    References to travel parties (individual travellers, user profiles or
+                    assets) this selection applies to. Must match the `travellerReference`
+                    values used in the related search and must be compatible with the
+                    offer's `eligibleTravellerIds` if present.
+                  items:
+                    $ref: "#/components/schemas/travellerReference"
                 selectedAncillaryIds:
                   type: array
                   description: "List of ancillaryIds to include specifically for this offer instance."
                   items:
                     $ref: "#/components/schemas/ancillaryReference"
-          type:
-            type: string
-            enum: [ select_offers ]
 
     packageInput:
       allOf:
@@ -2033,6 +2044,16 @@ components:
                 $ref: "#/components/schemas/guarantee"
             expiryTime:
               $ref: '#/components/schemas/dateTime'
+            eligibleTravellerIds:
+              type: array
+              minItems: 1
+              description: >
+                References to travel parties (individual travellers, user profiles or
+                assets) that are eligible for this offer in the context of the search.
+                Items must match `travellerReference` values supplied in the corresponding
+                search request.
+              items:
+                $ref: "#/components/schemas/travellerReference"
         links:
           type: array
           items:
@@ -2504,7 +2525,7 @@ components:
         - id
         properties:
           id:
-            $ref: "#/components/schemas/assetReference"
+            $ref: "#/components/schemas/travellerReference"
 
     userProfile:
       allOf:
@@ -2515,7 +2536,7 @@ components:
         - id
         properties:
           id:
-            $ref: "#/components/schemas/shortString"
+            $ref: "#/components/schemas/travellerReference"
           count:
             $ref: "#/components/schemas/shortInt"
             default: 1
@@ -3359,6 +3380,9 @@ components:
     travellerReference:
       allOf:
         - $ref: "#/components/schemas/normalString"
+      description: >
+        Reference to a travel party member (individual traveller, user profile, or
+        travelling asset). Matches the id of an object implementing `travelParty`.
 
     productReference:
       type: object


### PR DESCRIPTION
This PR introduces end-to-end traveller identification based on `travellerReference` across the search → select → purchase flow.

*Key changes*
- `selectOffersInput`
  - Extends `selections` items with a required `travellerIds: travellerReference[]` field to bind each selected offer to specific travel party members (individual travellers, user profiles, or assets).

- `offer` / offer collection
  - Adds an optional `eligibleTravellerIds: travellerReference[]` field on `offer` to describe which travel party members are eligible for that offer in the context of a search.

- `userProfile` and `travellingAsset`
  - Changes `userProfile.id` and `travellingAsset.id` to use `travellerReference`.
  - Aligns all travel party member identifiers on a single `travellerReference` type.

- `travellerReference`
  - Documents that it is a reference to any `travelParty` member (individual traveller, user profile or travelling asset).

*Rationale*
These changes ensure a consistent `travellerReference` is used throughout the API so clients can:

- Specify which travel party members an offer selection applies to.
- Understand which travellers are eligible for a given offer in search results.
- Reliably correlate search and selection with concrete travel party members and assets.
